### PR TITLE
Docker Support for universal-server

### DIFF
--- a/universal-server/.dockerignore
+++ b/universal-server/.dockerignore
@@ -1,0 +1,12 @@
+build_deb_server/
+build_rpm_server/
+dist/
+*.deb
+*.rpm
+__pycache__/
+*.pyc
+.venv/
+.git/
+*.md
+build_deb_server.sh
+build_rpm_server.sh

--- a/universal-server/Dockerfile
+++ b/universal-server/Dockerfile
@@ -1,0 +1,32 @@
+# Stage 1: Build dependencies
+FROM python:3.11-alpine AS builder
+
+RUN apk add --no-cache gcc musl-dev libxml2-dev libxslt-dev libffi-dev
+
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+RUN pip install --no-cache-dir flask requests pywemo
+
+# Stage 2: Runtime
+FROM python:3.11-alpine
+
+RUN apk add --no-cache libxml2 libxslt su-exec
+
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+COPY wemo_server.py .
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+RUN mkdir -p /data
+
+EXPOSE 5000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:5000/api/status')" || exit 1
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/universal-server/docker-compose.yml
+++ b/universal-server/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  wemo-server:
+    build: .
+    container_name: wemo-ops-server
+    restart: unless-stopped
+    network_mode: host
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=America/New_York
+    volumes:
+      - wemo-data:/data
+
+volumes:
+  wemo-data:

--- a/universal-server/entrypoint.sh
+++ b/universal-server/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+
+# Create group and user with requested IDs
+addgroup -g "$PGID" wemo 2>/dev/null || true
+adduser -D -u "$PUID" -G wemo -h /home/wemo wemo 2>/dev/null || true
+
+# Symlink /data to where wemo_server.py expects it for non-root user
+mkdir -p /home/wemo/.local/share
+ln -sfn /data /home/wemo/.local/share/WemoOps
+
+# Fix ownership
+chown -R "$PUID:$PGID" /data /home/wemo
+
+# Drop privileges and run
+exec su-exec wemo python /app/wemo_server.py


### PR DESCRIPTION
Added the ability to run universal-server in a docker container. Limited testing has returned successful results. The docker-compose.yml will build from the Dockerfile. In the event you publish this to a container registry, the compose file can be modified to pull from registry and not build.

Tested on macOS, `docker compose up -d --build` from within the universal-server directory.