### PR TITLE
Fix MCP Registry Validation - Release v1.0.1

### DIFF
--- a/mcp/CHANGELOG.md
+++ b/mcp/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to the WeMo MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2026-02-16
+
+### Fixed
+- 📝 **MCP Registry validation** - Added `mcp-name: io.github.qrussell/wemo` to package README for registry ownership validation
+- 🔧 **Registry metadata** - Updated `server.json` to version 1.0.1
+
+This patch release enables successful publication to the official MCP Registry at https://registry.modelcontextprotocol.io/
+
 ## [1.0.0] - 2026-02-16
 
 ### Added

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -2,6 +2,8 @@
 
 Control WeMo smart home devices through AI assistants using natural language.
 
+**mcp-name: io.github.qrussell/wemo**
+
 [![PyPI version](https://badge.fury.io/py/wemo-mcp-server.svg)](https://pypi.org/project/wemo-mcp-server/)
 [![Publish MCP Server to PyPI](https://github.com/qrussell/wemo-ops-center/actions/workflows/pypi-publish.yml/badge.svg)](https://github.com/qrussell/wemo-ops-center/actions/workflows/pypi-publish.yml)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wemo-mcp-server"
-version = "1.0.0"
+version = "1.0.1"
 description = "Model Context Protocol server for WeMo smart home device discovery and control"
 authors = [
     {name = "apiarya", email = "izzasnvyp7@privaterelay.appleid.com"}

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/qrussell/wemo-ops-center",
     "source": "github"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "wemo-mcp-server",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "transport": {
         "type": "stdio"
       }

--- a/mcp/src/wemo_mcp_server/__init__.py
+++ b/mcp/src/wemo_mcp_server/__init__.py
@@ -1,6 +1,6 @@
 """WeMo MCP Server - Network scanning and device discovery for WeMo devices."""
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 from .server import main
 


### PR DESCRIPTION
# Fix MCP Registry Validation - v1.0.1

Hi @qrussell! 🔧

The MCP Registry submission you attempted failed because of a missing ownership validation marker. I've fixed it!

## Problem

The registry returned this error:
```
The server name 'io.github.qrussell/wemo' must appear as 'mcp-name: io.github.qrussell/wemo' 
in the package README
```

## Solution - v1.0.1

This PR adds the required metadata and bumps to version 1.0.1:

### Changes:
1. ✅ **Added `mcp-name` metadata** to README.md
   ```markdown
   **mcp-name: io.github.qrussell/wemo**
   ```
   This validates your ownership of the `io.github.qrussell/*` namespace.

2. ✅ **Version bump to 1.0.1** in:
   - `pyproject.toml`
   - `src/wemo_mcp_server/__init__.py`
   - `server.json`

3. ✅ **Updated CHANGELOG.md** with 1.0.1 release notes

## Next Steps After Merge:

```bash
# 1. Tag and push v1.0.1
git tag mcp-v1.0.1
git push origin mcp-v1.0.1

# 2. Create GitHub release for v1.0.1
#    This triggers the automated PyPI publish workflow

# 3. Wait ~1-2 minutes for PyPI publish to complete
#    Verify at: https://pypi.org/project/wemo-mcp-server/

# 4. Publish to MCP Registry
cd mcp
mcp-publisher publish
```

✅ **The registry validation will pass once v1.0.1 is on PyPI!**

This is just a patch release to satisfy the registry's validation requirements. No functional changes.
