### PR TITLE
Fix registry URL validation error

### DIFF
--- a/mcp/server.json
+++ b/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.qrussell/wemo",
   "description": "Control WeMo smart home devices - discover, toggle, adjust brightness, and manage HomeKit codes",
   "repository": {
-    "url": "https://github.com/qrussell/wemo-ops-center/tree/main/mcp#wemo-mcp-server",
+    "url": "https://github.com/qrussell/wemo-ops-center/tree/main/mcp",
     "source": "github"
   },
   "version": "1.0.1",


### PR DESCRIPTION
# Fix Registry URL Validation Error

## Issue
The MCP Registry validation fails when attempting to republish due to an invalid repository URL format:

```
❌ Validation failed with 1 issue(s):
invalid repository URL: https://github.com/qrussell/wemo-ops-center/tree/main/mcp#wemo-mcp-server
```

## Fix
Removed the URL fragment (`#wemo-mcp-server`) from the repository URL in `server.json`.

**Before:**
```json
"url": "https://github.com/qrussell/wemo-ops-center/tree/main/mcp#wemo-mcp-server"
```

**After:**
```json
"url": "https://github.com/qrussell/wemo-ops-center/tree/main/mcp"
```

## Testing
After this fix, you should be able to successfully republish to the MCP Registry:

```bash
cd mcp
mcp-publisher publish
```

## Impact
- ✅ Registry validation will pass
- ✅ Users can still reach the MCP subdirectory (fragments are client-side only)
- ✅ No version bump needed (metadata-only change)
